### PR TITLE
Speakers grouping and fast navigation by speakers list (index list - …

### DIFF
--- a/DotNetRu.Clients.Portable/ViewModel/SpeakersViewModel.cs
+++ b/DotNetRu.Clients.Portable/ViewModel/SpeakersViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Windows.Input;
 
@@ -22,16 +23,19 @@
         {
         }
 
-        public ObservableRangeCollection<SpeakerModel> Speakers { get; } =
-            new ObservableRangeCollection<SpeakerModel>();
+        public ObservableRangeCollection<Grouping<string, SpeakerModel>> _speakers = new ObservableRangeCollection<Grouping<string, SpeakerModel>>();
+        public ObservableCollection<Grouping<string, SpeakerModel>> Speakers => _speakers;
 
         #region Sorting
 
         private void SortSpeakers(IEnumerable<SpeakerModel> speakers)
         {
-            var speakersSorted = from speaker in speakers orderby speaker.FullName select speaker;
+            var speakersSorted = from speaker in speakers 
+                                    orderby speaker.FullName 
+                                    group speaker by speaker.FullName[0].ToString().ToUpperInvariant() into speakerGroup
+                                    select new Grouping<string, SpeakerModel>(speakerGroup.Key, speakerGroup);
 
-            this.Speakers.ReplaceRange(speakersSorted);
+            _speakers.ReplaceRange(speakersSorted);
         }
 
         #endregion

--- a/DotNetRu.Clients.Portable/ViewModel/SpeakersViewModel.cs
+++ b/DotNetRu.Clients.Portable/ViewModel/SpeakersViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Globalization;
     using System.Linq;
     using System.Windows.Input;
 
@@ -23,19 +24,19 @@
         {
         }
 
-        public ObservableRangeCollection<Grouping<string, SpeakerModel>> _speakers = new ObservableRangeCollection<Grouping<string, SpeakerModel>>();
-        public ObservableCollection<Grouping<string, SpeakerModel>> Speakers => _speakers;
+        public ObservableRangeCollection<Grouping<char, SpeakerModel>> speakers = new ObservableRangeCollection<Grouping<char, SpeakerModel>>();
+        public ObservableCollection<Grouping<char, SpeakerModel>> Speakers => speakers;
 
         #region Sorting
 
         private void SortSpeakers(IEnumerable<SpeakerModel> speakers)
         {
             var speakersSorted = from speaker in speakers 
-                                    orderby speaker.FullName 
-                                    group speaker by speaker.FullName[0].ToString().ToUpperInvariant() into speakerGroup
-                                    select new Grouping<string, SpeakerModel>(speakerGroup.Key, speakerGroup);
+                                    orderby speaker.FirstName 
+                                    group speaker by Char.ToUpperInvariant(speaker.FirstName[0]) into speakerGroup
+                                    select new Grouping<char, SpeakerModel>(speakerGroup.Key, speakerGroup);
 
-            _speakers.ReplaceRange(speakersSorted);
+            this.speakers.ReplaceRange(speakersSorted);
         }
 
         #endregion

--- a/DotNetRu.Clients.UI/Pages/Speakers/SpeakersPage.xaml
+++ b/DotNetRu.Clients.UI/Pages/Speakers/SpeakersPage.xaml
@@ -1,8 +1,9 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage 
     xmlns="http://xamarin.com/schemas/2014/forms" 
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="DotNetRu.Clients.UI.Pages.Speakers.SpeakersPage"
+    xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
 	  xmlns:pages="clr-namespace:DotNetRu.Clients.UI.Pages;assembly=DotNetRu.Clients.UI"
 	  xmlns:cells="clr-namespace:DotNetRu.Clients.UI.Cells;assembly=DotNetRu.Clients.UI"
 	  Title="{Binding Resources[Speakers]}"
@@ -14,17 +15,31 @@
 	     <ListView 
 	            x:Name="ListViewSpeakers"
 	            ItemsSource="{Binding Speakers}"
-	            IsGroupingEnabled="false"
-	            HasUnevenRows ="false"
+	            IsGroupingEnabled="true"
+                GroupDisplayBinding="{Binding Key}" 
+                GroupShortNameBinding="{Binding Key}"
+	            HasUnevenRows ="true"
 	            RowHeight="90"
 	            IsPullToRefreshEnabled="false"
 	            IsRefreshing="{Binding IsBusy, Mode=OneWay}"
 	            IsVisible="{Binding IsNotBusy}"
+                android:ListView.IsFastScrollEnabled="True"
 	            AbsoluteLayout.LayoutFlags="All" 
 	            AbsoluteLayout.LayoutBounds="0,0,1,1">
 	        <ListView.SeparatorColor>
 	            <OnPlatform x:TypeArguments="Color" iOS="{StaticResource ListSeparator}" Android="Transparent"/>
 	        </ListView.SeparatorColor>
+            <ListView.GroupHeaderTemplate>
+              <DataTemplate>
+                <ViewCell Height="25">
+                  <StackLayout VerticalOptions="FillAndExpand"
+                               Padding="5"
+                               BackgroundColor="{StaticResource Primary}">
+                    <Label Text="{Binding Key}" TextColor="White" VerticalOptions="Center"/>
+                  </StackLayout>
+                </ViewCell>
+              </DataTemplate>
+            </ListView.GroupHeaderTemplate>
 	      <ListView.ItemTemplate>
 	        <DataTemplate>
 	            <ViewCell StyleId="disclosure">

--- a/DotNetRu.Clients.UI/Pages/Speakers/SpeakersPage.xaml
+++ b/DotNetRu.Clients.UI/Pages/Speakers/SpeakersPage.xaml
@@ -1,66 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages:BasePage 
-    xmlns="http://xamarin.com/schemas/2014/forms" 
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="DotNetRu.Clients.UI.Pages.Speakers.SpeakersPage"
     xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
-	  xmlns:pages="clr-namespace:DotNetRu.Clients.UI.Pages;assembly=DotNetRu.Clients.UI"
-	  xmlns:cells="clr-namespace:DotNetRu.Clients.UI.Cells;assembly=DotNetRu.Clients.UI"
-	  Title="{Binding Resources[Speakers]}"
+    xmlns:pages="clr-namespace:DotNetRu.Clients.UI.Pages;assembly=DotNetRu.Clients.UI"
+    xmlns:cells="clr-namespace:DotNetRu.Clients.UI.Cells;assembly=DotNetRu.Clients.UI"
+    Title="{Binding Resources[Speakers]}"
     x:Name="SpeakersScreen"
     Icon="tab_speakers.png"
     BackgroundColor="{DynamicResource WindowBackground}">
-	<ContentPage.Content>
-	   <AbsoluteLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
-	     <ListView 
-	            x:Name="ListViewSpeakers"
-	            ItemsSource="{Binding Speakers}"
-	            IsGroupingEnabled="true"
-                GroupDisplayBinding="{Binding Key}" 
+    <ContentPage.Content>
+        <AbsoluteLayout HorizontalOptions="FillAndExpand"
+            VerticalOptions="FillAndExpand">
+            <ListView x:Name="ListViewSpeakers"
+                ItemsSource="{Binding Speakers}"
+                IsGroupingEnabled="true"
+                GroupDisplayBinding="{Binding Key}"
                 GroupShortNameBinding="{Binding Key}"
-	            HasUnevenRows ="true"
-	            RowHeight="90"
-	            IsPullToRefreshEnabled="false"
-	            IsRefreshing="{Binding IsBusy, Mode=OneWay}"
-	            IsVisible="{Binding IsNotBusy}"
+                HasUnevenRows="true"
+                RowHeight="90"
+                IsPullToRefreshEnabled="false"
+                IsRefreshing="{Binding IsBusy, Mode=OneWay}"
+                IsVisible="{Binding IsNotBusy}"
                 android:ListView.IsFastScrollEnabled="True"
-	            AbsoluteLayout.LayoutFlags="All" 
-	            AbsoluteLayout.LayoutBounds="0,0,1,1">
-	        <ListView.SeparatorColor>
-	            <OnPlatform x:TypeArguments="Color" iOS="{StaticResource ListSeparator}" Android="Transparent"/>
-	        </ListView.SeparatorColor>
-            <ListView.GroupHeaderTemplate>
-              <DataTemplate>
-                <ViewCell Height="25">
-                  <StackLayout VerticalOptions="FillAndExpand"
-                               Padding="5"
-                               BackgroundColor="{StaticResource Primary}">
-                    <Label Text="{Binding Key}" TextColor="White" VerticalOptions="Center"/>
-                  </StackLayout>
-                </ViewCell>
-              </DataTemplate>
-            </ListView.GroupHeaderTemplate>
-	      <ListView.ItemTemplate>
-	        <DataTemplate>
-	            <ViewCell StyleId="disclosure">
-	                <cells:SpeakerCellView />
-	            </ViewCell>
-	        </DataTemplate>
-	      </ListView.ItemTemplate>
-	    </ListView>
-	        <StackLayout IsVisible="{Binding IsBusy}"
-	                                   AbsoluteLayout.LayoutFlags="PositionProportional"
-	                                   AbsoluteLayout.LayoutBounds="0.5,0.5,-1,-1">
-	                                   <StackLayout.Orientation>
-	                                    <OnPlatform x:TypeArguments="StackOrientation" iOS="Horizontal"/>
-	                                   </StackLayout.Orientation>
-	            <ActivityIndicator IsRunning="{Binding IsBusy}" >
-	                <ActivityIndicator.Color>
-	                    <OnPlatform x:TypeArguments="Color" Android="{StaticResource Accent}"/>
-	                </ActivityIndicator.Color>
-	            </ActivityIndicator>
-	            <Label Text="Loading Speakers..." HorizontalOptions="Center" Style="{DynamicResource EvolveListItemTextStyle}"/>
-	       </StackLayout>
-	    </AbsoluteLayout>
-	</ContentPage.Content>
+                AbsoluteLayout.LayoutFlags="All"
+                AbsoluteLayout.LayoutBounds="0,0,1,1">
+                <ListView.SeparatorColor>
+                    <OnPlatform x:TypeArguments="Color"
+                        iOS="{StaticResource ListSeparator}"
+                        Android="Transparent" />
+                </ListView.SeparatorColor>
+                <ListView.GroupHeaderTemplate>
+                    <DataTemplate>
+                        <ViewCell Height="25">
+                            <StackLayout VerticalOptions="FillAndExpand"
+                                Padding="5"
+                                BackgroundColor="{StaticResource Primary}">
+                                <Label Text="{Binding Key}"
+                                    TextColor="White"
+                                    VerticalOptions="Center" />
+                            </StackLayout>
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.GroupHeaderTemplate>
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <ViewCell StyleId="disclosure">
+                            <cells:SpeakerCellView />
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <StackLayout IsVisible="{Binding IsBusy}"
+                AbsoluteLayout.LayoutFlags="PositionProportional"
+                AbsoluteLayout.LayoutBounds="0.5,0.5,-1,-1">
+                <StackLayout.Orientation>
+                    <OnPlatform x:TypeArguments="StackOrientation"
+                        iOS="Horizontal" />
+                </StackLayout.Orientation>
+                <ActivityIndicator IsRunning="{Binding IsBusy}">
+                    <ActivityIndicator.Color>
+                        <OnPlatform x:TypeArguments="Color"
+                            Android="{StaticResource Accent}" />
+                    </ActivityIndicator.Color>
+                </ActivityIndicator>
+                <Label Text="Loading Speakers..."
+                    HorizontalOptions="Center"
+                    Style="{DynamicResource EvolveListItemTextStyle}" />
+            </StackLayout>
+        </AbsoluteLayout>
+    </ContentPage.Content>
 </pages:BasePage>


### PR DESCRIPTION
…iOS, fast scroll - Android) were added.

Screenshots (click for download from OneDrive): 
- [iOS](https://1drv.ms/i/s!Ak51a4YkJKu2x3AqGfwU2hfRHoYu)
- [Android](https://1drv.ms/i/s!Ak51a4YkJKu2x3J3p4A5Rp2ywBkJ) - now fast scroll uses yellow color (defined as accent color in the Android theme), probably it should be changed to purple (primary color)/ 