### PR TITLE
Fix #250: sort communities

### DIFF
--- a/DotNetRu.Clients.UI/About/AboutViewModel.cs
+++ b/DotNetRu.Clients.UI/About/AboutViewModel.cs
@@ -52,9 +52,19 @@ namespace DotNetRu.Clients.Portable.ViewModel
             }));
 
             var communities = RealmService.Get<CommunityModel>();
-            aboutPageItems.Add(new Grouping<string, AboutPageItem>("OurCommunities", communities.Select(x => new AboutPageItem
+            var sessions = RealmService.Get<MeetupModel>();
+            var communitiesWithFirstSessionDate = communities.Join(
+                sessions,
+                c => c.Id,
+                s => s.CommunityID,
+                (c, s) => new
+                {
+                    Community = c,
+                    FirstSessionDate = s.Sessions.OrderBy(session => session.StartTime).FirstOrDefault()?.StartTime
+                }).OrderBy(x => x.FirstSessionDate).GroupBy(x => x.Community.Id).Select(x => x.First());
+            aboutPageItems.Add(new Grouping<string, AboutPageItem>("OurCommunities", communitiesWithFirstSessionDate.Select(x => new AboutPageItem
             {
-                Community = x,
+                Community = x.Community,
                 AboutItemType = AboutItemType.Community
             })));
 


### PR DESCRIPTION
Исправлена isuue #250 : теперь на странице "About" все сообщества ("Our communities") отсортированы в порядке старшинства в соответствии с [официальными рекомендациями](https://github.com/DotNetRu/Audit/wiki/Community-Order).

![communities_sorted](https://user-images.githubusercontent.com/29679226/76709997-a09ef400-6714-11ea-8d2d-0db00e7b2337.png)