### PR TITLE
Fix #269: open tweets from News form

### DIFF
--- a/DotNetRu.Clients.UI/News/NewsPage.xaml.cs
+++ b/DotNetRu.Clients.UI/News/NewsPage.xaml.cs
@@ -1,3 +1,5 @@
+using Xamarin.Essentials;
+
 namespace DotNetRu.Clients.UI.Pages.Home
 {
     using System;
@@ -29,7 +31,14 @@ namespace DotNetRu.Clients.UI.Pages.Home
                             Command = this.NewsViewModel.RefreshCommand
                         });
             }
-            this.ListViewSocial.ItemSelected += (sender, e) => this.ListViewSocial.SelectedItem = null;
+            this.ListViewSocial.ItemSelected += async (sender, e) =>
+            {
+                if (e.SelectedItem is Tweet tweet && !string.IsNullOrWhiteSpace(tweet.Url))
+                {
+                    await Launcher.OpenAsync(new Uri(tweet.Url));
+                }
+                this.ListViewSocial.SelectedItem = null;
+            };
         }
 
         public override AppPage PageType => AppPage.News;


### PR DESCRIPTION
При нажатии на новость теперь открываться её оригинальный Твит (issue #269 ).

![open_tweet](https://user-images.githubusercontent.com/29679226/76794717-a958fe00-67d8-11ea-8625-7e2b227498f6.gif)