### PR TITLE
Fix #255 (again) : hide scrollbar in sections

### DIFF
--- a/DotNetRu.Android/DotNetRu.Android.csproj
+++ b/DotNetRu.Android/DotNetRu.Android.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Localize.cs" />
     <Compile Include="MainActivity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Renderers\NonScrollableListViewRenderer.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="MainApplication.cs" />
     <Compile Include="Helpers\Settings.cs" />


### PR DESCRIPTION
Почему-то добавленный в PR #272 файл `DotNetRu.Android/Renderers/NonScrollableListViewRenderer.cs` не был включен в проект.

![renderer](https://user-images.githubusercontent.com/29679226/79265702-2f7f6780-7e9f-11ea-8e96-3c4a63e64325.png)`

Добавил его. Проблема #255 не должна воспроизводиться.